### PR TITLE
fix About.test.tsx to assert structure, not literal marketing copy

### DIFF
--- a/client/tests/unit/components/overlays/About.test.tsx
+++ b/client/tests/unit/components/overlays/About.test.tsx
@@ -10,14 +10,24 @@ vi.mock("@/utils", () => ({
 }));
 
 describe("About", () => {
-  it("renders body copy and credit line with contact link", () => {
-    render(
+  it("renders the translated body copy and a credit line with a working contact link", () => {
+    const { container } = render(
       <MemoryRouter>
         <About />
       </MemoryRouter>,
     );
 
-    expect(screen.getByText(/Welcome to the Council of Foods!/)).toBeInTheDocument();
+    // The body is themed marketing copy that's expected to vary per deployment (see
+    // translation_en.json's "about.body") — assert it renders with real content, not its
+    // exact prose, so an intentional copy edit doesn't fail this test (see TESTING.md:
+    // never assert on content that changes independently of behavior).
+    const paragraphs = container.querySelectorAll("p");
+    expect(paragraphs.length).toBeGreaterThanOrEqual(2);
+    expect(paragraphs[0].textContent).toBeTruthy();
+    expect(paragraphs[0].textContent!.length).toBeGreaterThan(50);
+
+    // The credit line is stable boilerplate ("who made this"), not themed copy, so it's
+    // safe to assert directly.
     expect(screen.getByText(/a project by/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Nonhuman Nonsense" })).toHaveAttribute(
       "href",


### PR DESCRIPTION
Was failing on asilomar: the test hardcoded the exact English "about.body" translation string, but this branch's copy was deliberately rewritten for the Asilomar/synthetic-biology theme (different prose, no longer matching the old text verbatim). The component's actual behavior never changed — it always just renders t("about.body") plus a credit line — so this was a test asserting content instead of behavior (see TESTING.md and the LLM/TTS-boundary rule: never assert on content that changes independently of behavior).

Now asserts structurally instead: a body paragraph renders with substantial real content (length > 50, non-empty) rather than its exact prose, while keeping the credit-line/contact-link assertions as-is since that boilerplate is stable across themes. Matches the sibling Contact.test.tsx's existing pattern (real translations render, but only stable structural elements are asserted).

Not touched: the other asilomar test failure (FoodVideoIntegrity — orphan honey video/image assets with no matching character in foods_en.json) is a real content bug from a "merge main into asilomar" that keeps overwriting the character roster, not a test problem — that test is correctly doing its job and the fix belongs to the content, not the suite.